### PR TITLE
Make FormatByPath return single argument

### DIFF
--- a/fileformat.go
+++ b/fileformat.go
@@ -74,19 +74,18 @@ var (
 
 // FormatByPath determines file format by file extension
 // extracted from path. If extension belongs to unsupported
-// format, second return argument will be false.
-func FormatByPath(path string) (Format, bool) {
+// format, nil is returned.
+func FormatByPath(path string) Format {
 	ext := filepath.Ext(path)
 	switch {
 	case WAV.MatchExtension(ext):
-		return WAV, true
+		return WAV
 	case MP3.MatchExtension(ext):
-		return MP3, true
+		return MP3
 	case FLAC.MatchExtension(ext):
-		return FLAC, true
-	default:
-		return nil, false
+		return FLAC
 	}
+	return nil
 }
 
 // MatchExtension checks if ext matches to one of the format's
@@ -144,8 +143,8 @@ func Walk(fn PipeFunc, recursive bool) filepath.WalkFunc {
 			return filepath.SkipDir
 		}
 
-		format, ok := FormatByPath(path)
-		if !ok {
+		format := FormatByPath(path)
+		if format == nil {
 			return nil
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module pipelined.dev/audio/fileformat
 go 1.13
 
 require (
-	github.com/stretchr/testify v1.4.0
 	pipelined.dev/audio/flac v0.3.0
 	pipelined.dev/audio/mp3 v0.5.0
 	pipelined.dev/audio/wav v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 github.com/d4l3k/messagediff v1.2.2-0.20190829033028-7e0a312ae40b/go.mod h1:Oozbb1TVXFac9FtSIxHBMnBCq2qeH/2KkEQxENCrlLo=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-audio/audio v1.0.0 h1:zS9vebldgbQqktK4H0lUqWrG8P0NxCJVqcj7ZpNnwd4=
 github.com/go-audio/audio v1.0.0/go.mod h1:6uAu0+H2lHkwdGsAY+j2wHPNPpPoeg5AaEFh9FlA+Zs=
 github.com/go-audio/riff v1.0.0 h1:d8iCGbDvox9BfLagY94fBynxSPHO80LmZCaOsmKxokA=
@@ -20,11 +18,6 @@ github.com/mewkiz/pkg v0.0.0-20190919212034-518ade7978e2/go.mod h1:3E2FUC/qYUfM8
 github.com/mewkiz/pkg v0.0.0-20200702171441-dd47075182ea h1:LUvH2BZ4TRTtGAm7IPkIgdZ7rOobER2WQ/h5VUIwm9c=
 github.com/mewkiz/pkg v0.0.0-20200702171441-dd47075182ea/go.mod h1:3E2FUC/qYUfM8+r9zAwpeHJzqRVVMIYnpzD/clwWxyA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/viert/lame v0.0.0-20190823071122-49a063e7d5e6 h1:1XPLOPnNgpmWkgV4Fkx3xZoNRqygHvFaXT+VQeZPs4I=
 github.com/viert/lame v0.0.0-20190823071122-49a063e7d5e6/go.mod h1:iTcgj2s0jGfKkwHeeiNeBBZyNsW+GaK+B8IzbSvOu2w=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -35,10 +28,6 @@ golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190429190828-d89cdac9e872/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 pipelined.dev/audio/flac v0.3.0 h1:HOm8UdcbtTVqXZgHTkH+gGb19ZIpWhpON7c7qENm0T0=
 pipelined.dev/audio/flac v0.3.0/go.mod h1:eO5XXVyvxgy++T9od00B2psIsCeitEHmxzQnzWB7las=
 pipelined.dev/audio/mp3 v0.5.0 h1:MxAaSSe2DIOlsqTXYb0r1S3PvUmhmCJWYAOqRiVdk9U=


### PR DESCRIPTION
Because Format is an interface, single result is enough. Also, this commit removes test dependency.