### PR TITLE
make Format struct

### DIFF
--- a/fileformat.go
+++ b/fileformat.go
@@ -15,51 +15,48 @@ import (
 	"pipelined.dev/pipe"
 )
 
-type (
-	// Format of the file that contains audio signal.
-	Format interface {
-		Source(io.ReadSeeker) pipe.SourceAllocatorFunc
-		DefaultExtension() string
-		MatchExtension(string) bool
-		Extensions() []string
-	}
-
-	// generic struct that implements Format interface.
-	format struct {
-		defaultExtension string
-		extensions       []string
-	}
-)
+// Format of the file that contains audio signal.
+type Format struct {
+	defaultExtension string
+	extensions       []string
+	source           func(io.ReadSeeker) pipe.SourceAllocatorFunc
+}
 
 var (
-	// WAV represents Waveform Audio file format.
-	WAV = &format{
+	wavFormat = Format{
 		defaultExtension: ".wav",
 		extensions: []string{
 			".wav",
 			".wave",
 		},
+		source: func(rs io.ReadSeeker) pipe.SourceAllocatorFunc {
+			return wav.Source(rs)
+		},
 	}
 
-	// MP3 represents MPEG-1 or MPEG-2 Audio Layer III file format.
-	MP3 = &format{
+	mp3Format = Format{
 		defaultExtension: ".mp3",
 		extensions: []string{
 			".mp3",
 		},
+		source: func(rs io.ReadSeeker) pipe.SourceAllocatorFunc {
+			return mp3.Source(rs)
+		},
 	}
 
-	// FLAC represents Free Lossless Audio Codec file format.
-	FLAC = &format{
+	flacFormat = Format{
 		defaultExtension: ".flac",
 		extensions: []string{
 			".flac",
 		},
+		source: func(rs io.ReadSeeker) pipe.SourceAllocatorFunc {
+			return flac.Source(rs)
+		},
 	}
 
 	// formatByExtension = mapFormatByExtension(WAV, MP3, FLAC)
-	formatByExtension = func(formats ...Format) map[string]Format {
-		m := make(map[string]Format)
+	formatByExtension = func(formats ...*Format) map[string]*Format {
+		m := make(map[string]*Format)
 		for _, format := range formats {
 			for _, ext := range format.Extensions() {
 				if _, ok := m[ext]; ok {
@@ -69,28 +66,34 @@ var (
 			}
 		}
 		return m
-	}(WAV, MP3, FLAC)
+	}(&wavFormat, &mp3Format, &flacFormat)
 )
+
+// WAV returns Waveform Audio file format.
+func WAV() *Format {
+	return &wavFormat
+}
+
+// MP3 returns MPEG-1 or MPEG-2 Audio Layer III file format.
+func MP3() *Format {
+	return &mp3Format
+}
+
+// FLAC returns Free Lossless Audio Codec file format.
+func FLAC() *Format {
+	return &flacFormat
+}
 
 // FormatByPath determines file format by file extension
 // extracted from path. If extension belongs to unsupported
 // format, nil is returned.
-func FormatByPath(path string) Format {
-	ext := filepath.Ext(path)
-	switch {
-	case WAV.MatchExtension(ext):
-		return WAV
-	case MP3.MatchExtension(ext):
-		return MP3
-	case FLAC.MatchExtension(ext):
-		return FLAC
-	}
-	return nil
+func FormatByPath(path string) *Format {
+	return formatByExtension[strings.ToLower(filepath.Ext(path))]
 }
 
 // MatchExtension checks if ext matches to one of the format's
 // extensions. Case is ignored.
-func (f *format) MatchExtension(ext string) bool {
+func (f *Format) MatchExtension(ext string) bool {
 	format, ok := formatByExtension[strings.ToLower(ext)]
 	if !ok {
 		return false
@@ -100,31 +103,23 @@ func (f *format) MatchExtension(ext string) bool {
 
 // Source returns pipe.Source for corresponding format
 // with injected ReadSeeker.
-func (f *format) Source(rs io.ReadSeeker) pipe.SourceAllocatorFunc {
-	switch f {
-	case WAV:
-		return wav.Source(rs)
-	case MP3:
-		return mp3.Source(rs)
-	case FLAC:
-		return flac.Source(rs)
-	}
-	return nil
+func (f *Format) Source(rs io.ReadSeeker) pipe.SourceAllocatorFunc {
+	return f.source(rs)
 }
 
 // DefaultExtension of the format.
-func (f *format) DefaultExtension() string {
+func (f *Format) DefaultExtension() string {
 	return f.defaultExtension
 }
 
 // Extensions returns a slice of format's extensions.
-func (f *format) Extensions() []string {
+func (f *Format) Extensions() []string {
 	return append(f.extensions[:0:0], f.extensions...)
 }
 
 // PipeFunc is user-defined function that allows to process files during
 // filewalk.
-type PipeFunc func(Format, string, os.FileInfo) error
+type PipeFunc func(*Format, string, os.FileInfo) error
 
 // Walk takes user-defined pipe function and return filepath.WalkFunc.
 // It allows to use it with filepath.Walk function and execute pipe func

--- a/fileformat_test.go
+++ b/fileformat_test.go
@@ -33,7 +33,8 @@ func TestFilePump(t *testing.T) {
 	for _, test := range tests {
 		format := fileformat.FormatByPath(test.fileName)
 		if test.negative {
-			assertNil(t, "format", format)
+			var nilFormat *fileformat.Format
+			assertEqual(t, "format", format, nilFormat)
 		} else {
 			assertNotNil(t, "format", format)
 			source := format.Source(nil)

--- a/fileformat_test.go
+++ b/fileformat_test.go
@@ -44,19 +44,19 @@ func TestFilePump(t *testing.T) {
 
 func TestExtensions(t *testing.T) {
 	var tests = []struct {
-		format   fileformat.Format
+		format   *fileformat.Format
 		expected int
 	}{
 		{
-			fileformat.WAV,
+			fileformat.WAV(),
 			2,
 		},
 		{
-			fileformat.MP3,
+			fileformat.MP3(),
 			1,
 		},
 		{
-			fileformat.FLAC,
+			fileformat.FLAC(),
 			1,
 		},
 	}
@@ -71,7 +71,7 @@ func TestWalk(t *testing.T) {
 	testPositive := func(path string, recursive bool, expected int) func(*testing.T) {
 		return func(t *testing.T) {
 			processed := 0
-			fn := func(f fileformat.Format, path string, fi os.FileInfo) error {
+			fn := func(f *fileformat.Format, path string, fi os.FileInfo) error {
 				processed++
 				return nil
 			}
@@ -90,7 +90,7 @@ func TestWalk(t *testing.T) {
 	testFailedPipe := func(path string) func(*testing.T) {
 		return func(t *testing.T) {
 			err := filepath.Walk(path,
-				fileformat.Walk(func(fileformat.Format, string, os.FileInfo) error {
+				fileformat.Walk(func(*fileformat.Format, string, os.FileInfo) error {
 					return fmt.Errorf("pipe error")
 				}, false))
 			assertNotNil(t, "error", err)


### PR DESCRIPTION
Format interface was a bad abstraction. It had switches in multiple methods. New struct type is self-contained, so interface is not needed. Global variables are protected by using unexported fields and providing methods for interaction.